### PR TITLE
Add sign-in/sign-up forms validations

### DIFF
--- a/__test__/components/Button/Button.test.tsx
+++ b/__test__/components/Button/Button.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { SessionProvider } from "next-auth/react";
 
 import Button from "@/components/Button";
-import { ButtonVariant } from "@/components/Button/Button";
+import { ButtonVariant } from "@/components/Button/Button.types";
 import { mockSessionWithNoUser } from "@/mocks/testMocks";
 
 describe("Button", () => {
@@ -19,14 +19,14 @@ describe("Button", () => {
   it("Should have primary styles applied", () => {
     render(
       <SessionProvider session={mockSessionWithNoUser}>
-        <Button />
+        <Button variant={"primary" as ButtonVariant} />
       </SessionProvider>
     );
 
     const button = screen.getByRole("button");
 
     expect(button).toHaveClass(
-      "focus:outline-none transition ease-in-out duration-300 rounded-lg bg-mantisDarker hover:bg-mantis text-white focus:ring-2 focus:ring-mantisDarker focus:ring-opacity-50 px-4 py-2 w-fit"
+      "focus:outline-none transition ease-in-out duration-300 rounded-lg bg-mantis hover:bg-mantisDarker text-white focus:ring-2 focus:ring-mantisDarker focus:ring-opacity-50 lg:bg-mantisDarker lg:hover:bg-mantis px-4 py-2 w-fit"
     );
   });
 

--- a/__test__/components/Input/FormikInput.test.tsx
+++ b/__test__/components/Input/FormikInput.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from "@testing-library/react";
+import { SessionProvider } from "next-auth/react";
+
+import FormikInput from "@/components/Input/FormikInput";
+import { mockField, mockMeta, mockSessionWithNoUser } from "@/mocks/testMocks";
+import { SIGN_IN_FORM_INITIAL_VALUE } from "@/modules/auth/components/SignIn/SignIn.schema";
+
+import { withFormikWrapper } from "./../../../mocks/testMocks";
+
+jest.mock("uuid", () => {
+  return {
+    v4: jest.fn(() => 1),
+  };
+});
+
+jest.mock("formik", () => ({
+  ...jest.requireActual("formik"),
+  useField: jest.fn(() => {
+    return [
+      mockField,
+      { ...mockMeta, touched: true, error: "Test Error Message" },
+    ];
+  }),
+}));
+
+const defaultProps = {
+  name: "Test Field",
+  placeholder: "Test input placeholder",
+};
+
+describe("FormikInput", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("Should render component without crashing", () => {
+    render(
+      <SessionProvider session={mockSessionWithNoUser}>
+        {withFormikWrapper(
+          <FormikInput {...defaultProps} />,
+          SIGN_IN_FORM_INITIAL_VALUE
+        )}
+      </SessionProvider>
+    );
+
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+  });
+
+  it("Should have error styles applied", async () => {
+    render(
+      <SessionProvider session={mockSessionWithNoUser}>
+        {withFormikWrapper(
+          <FormikInput {...defaultProps} error />,
+          SIGN_IN_FORM_INITIAL_VALUE
+        )}
+      </SessionProvider>
+    );
+
+    const input = screen.getByRole("textbox");
+
+    expect(input).toHaveClass(
+      "bg-errorBg border-2 border-tomato !placeholder-errorText focus:border-errorBg"
+    );
+
+    const errorMessage = await screen.findByText(/Test Error Message/);
+    expect(errorMessage).toBeInTheDocument();
+  });
+});

--- a/__test__/components/Input/Input.test.tsx
+++ b/__test__/components/Input/Input.test.tsx
@@ -10,7 +10,7 @@ jest.mock("uuid", () => {
   };
 });
 
-describe("Label", () => {
+describe("Input", () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
@@ -23,20 +23,6 @@ describe("Label", () => {
     );
 
     expect(screen.getByRole("textbox")).toBeInTheDocument();
-  });
-
-  it("Should have base styles applied", () => {
-    render(
-      <SessionProvider session={mockSessionWithNoUser}>
-        <Input isBaseInput />
-      </SessionProvider>
-    );
-
-    const input = screen.getByRole("textbox");
-
-    expect(input).toHaveClass(
-      "!bg-white !text-darkBlue !placeholder-darkBlue !border-2 !border-solid !border-mantis !focus:border-mantisDarker"
-    );
   });
 
   it("Should have normal styles applied", () => {
@@ -56,7 +42,7 @@ describe("Label", () => {
   it("Should have error styles applied", () => {
     render(
       <SessionProvider session={mockSessionWithNoUser}>
-        <Input error errorText="Test Error Message" />
+        <Input error />
       </SessionProvider>
     );
 
@@ -65,22 +51,6 @@ describe("Label", () => {
     expect(input).toHaveClass(
       "bg-errorBg border-2 border-tomato !placeholder-errorText focus:border-errorBg"
     );
-    expect(screen.getByText(/Test Error Message/)).toBeInTheDocument();
-  });
-
-  it("Should have error styles applied", () => {
-    render(
-      <SessionProvider session={mockSessionWithNoUser}>
-        <Input error errorText="Test Error Message" />
-      </SessionProvider>
-    );
-
-    const input = screen.getByRole("textbox");
-
-    expect(input).toHaveClass(
-      "bg-errorBg border-2 border-tomato !placeholder-errorText focus:border-errorBg"
-    );
-    expect(screen.getByText(/Test Error Message/)).toBeInTheDocument();
   });
 
   it("Should have disabled styles applied", () => {
@@ -103,5 +73,17 @@ describe("Label", () => {
     );
 
     expect(screen.getByText(/Test Label/)).toBeInTheDocument();
+  });
+
+  it("Should add to label '*' sign if field is required", () => {
+    render(
+      <SessionProvider session={mockSessionWithNoUser}>
+        <Input required label="Test Label" />
+      </SessionProvider>
+    );
+
+    const label = screen.getByText(/Test Label/);
+
+    expect(label.textContent).toEqual("Test Label *");
   });
 });

--- a/components/Button/Button.tsx
+++ b/components/Button/Button.tsx
@@ -1,21 +1,7 @@
 import clsx from "clsx";
 import React, { FC } from "react";
 
-type ButtonType = "submit" | "button" | "reset";
-export type ButtonVariant = "primary" | "secondary" | "danger" | "tertiary";
-type ButtonSize = "small" | "normal" | "large";
-type RoundedButton = "sm" | "md" | "lg";
-
-interface ButtonProps extends React.ComponentPropsWithoutRef<"button"> {
-  children?: React.ReactNode;
-  type?: ButtonType;
-  className?: string;
-  variant?: ButtonVariant;
-  size?: ButtonSize;
-  rounded?: RoundedButton;
-  disabled?: boolean;
-  fullWidth?: boolean;
-}
+import { ButtonProps } from "./Button.types";
 
 const Button: FC<ButtonProps> = ({
   children,
@@ -37,7 +23,7 @@ const Button: FC<ButtonProps> = ({
     },
     variant: {
       primary:
-        "bg-mantisDarker hover:bg-mantis text-white focus:ring-2 focus:ring-mantisDarker focus:ring-opacity-50",
+        "bg-mantis hover:bg-mantisDarker text-white focus:ring-2 focus:ring-mantisDarker focus:ring-opacity-50 lg:bg-mantisDarker lg:hover:bg-mantis ",
       secondary:
         "bg-lighterBlue hover:bg-blue focus:ring-2 focus:ring-lighterBlue focus:ring-opacity-50",
       tertiary:

--- a/components/Button/Button.types.ts
+++ b/components/Button/Button.types.ts
@@ -1,0 +1,15 @@
+export type ButtonType = "submit" | "button" | "reset";
+export type ButtonVariant = "primary" | "secondary" | "danger" | "tertiary";
+export type ButtonSize = "small" | "normal" | "large";
+export type RoundedButton = "sm" | "md" | "lg";
+
+export interface ButtonProps extends React.ComponentPropsWithoutRef<"button"> {
+  children?: React.ReactNode;
+  type?: ButtonType;
+  className?: string;
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  rounded?: RoundedButton;
+  disabled?: boolean;
+  fullWidth?: boolean;
+}

--- a/components/Input/FormikInput.tsx
+++ b/components/Input/FormikInput.tsx
@@ -1,0 +1,55 @@
+import clsx from "clsx";
+import { Field, FieldHookConfig, useField } from "formik";
+import React from "react";
+
+import { AuthFormInitialValues } from "@/modules/auth/auth.types";
+
+import Input from "./Input";
+import { InputProps } from "./Input.types";
+
+/**
+ * Common form text input component.
+ * IMPORTANT: This component should be wrapped inside Formik.
+ * @example
+ * <Formik initialValues={{ test: '' }} validationSchema={validation} onSubmit={() => {}>
+ *  {() => (
+ *    <Form>
+ *      <FormikInput id='name' name='name' placeholder='Enter your name'       startIcon={<BsFillTrashFill />} />
+ *    </Form>
+ *  )}
+ * </Formik>
+ */
+
+const FormikInput = ({
+  name = "",
+  placeholder,
+  className,
+  ...rest
+}: InputProps & FieldHookConfig<string>) => {
+  const [field, meta] = useField<AuthFormInitialValues>(name);
+
+  return (
+    <div
+      className={clsx("relative", [
+        meta.touched && meta.error ? "mb-8" : "mb-4",
+        className,
+      ])}
+    >
+      <Field
+        component={Input}
+        error={meta.touched && meta.error}
+        id={field.name}
+        placeholder={placeholder}
+        {...field}
+        {...rest}
+      />
+      {meta.touched && meta.error && (
+        <p className="absolute -bottom-5.5 pl-3 text-sm text-tomato font-medium lg:font-normal">
+          {meta.error}
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default FormikInput;

--- a/components/Input/Input.tsx
+++ b/components/Input/Input.tsx
@@ -2,32 +2,14 @@ import { clsx } from "clsx";
 import React, { FC } from "react";
 import { v4 as uuidv4 } from "uuid";
 
+import { InputProps } from "./Input.types";
 import Label from "../Label";
-
-type RoundedInput = "sm" | "md" | "lg";
-
-interface InputProps extends React.ComponentPropsWithoutRef<"input"> {
-  name?: string;
-  id?: string;
-  type?: string;
-  label?: string;
-  error?: boolean;
-  errorText?: string;
-  required?: boolean;
-  disabled?: boolean;
-  rounded?: RoundedInput;
-  placeholder?: string;
-  className?: string;
-  isBaseInput?: boolean;
-  fullWidth?: boolean;
-}
 
 const Input: FC<InputProps> = ({
   id = uuidv4(),
   name = "",
   label = "",
   error = false,
-  errorText = "",
   required = false,
   type = "text",
   disabled = false,
@@ -38,16 +20,15 @@ const Input: FC<InputProps> = ({
   fullWidth = false,
   ...rest
 }) => {
+  const commonInputStyles =
+    "border-transparent flex-1 appearance-none border py-2 px-2 shadow-sm text-base focus:outline-none focus:ring-black";
+
   const stylesConfig = {
-    base: "border-transparent flex-1 placeholder-darkBlue appearance-none border py-2 px-2 bg-white text-darkBlue shadow-sm text-base focus:outline-none focus:ring-black",
     state: {
-      general:
-        "!bg-white !text-darkBlue !placeholder-darkBlue !border-2 !border-solid !border-mantis !focus:border-mantisDarker",
-      normal:
-        "bg-mantis placeholder-white text-white border-2 border-mantisDarker focus:border-mantisDarker border-2 border-solid",
-      error:
-        "bg-errorBg border-2 border-tomato !placeholder-errorText focus:border-errorBg border-2 border-solid",
-      disabled: "pointer-events-none shadow-inner opacity-50",
+      general: `${commonInputStyles} bg-white text-darkBlue !placeholder-darkBlue border-2 border-solid border-mantis !focus:border-mantisDarker`,
+      normal: `${commonInputStyles} bg-mantis placeholder-white text-white border-2 border-mantisDarker focus:border-mantisDarker border-2 border-solid`,
+      error: `${commonInputStyles} bg-errorBg border-2 border-tomato !placeholder-errorText focus:border-errorBg border-2 border-solid`,
+      disabled: `${commonInputStyles} pointer-events-none shadow-inner opacity-50`,
     },
     rounded: {
       none: null,
@@ -58,7 +39,7 @@ const Input: FC<InputProps> = ({
   };
 
   return (
-    <div className={clsx("relative", [error && errorText ? "mb-8" : "mb-4.5"])}>
+    <>
       {label && (
         <Label id={id}>
           {label} {required && "*"}
@@ -66,7 +47,6 @@ const Input: FC<InputProps> = ({
       )}
       <input
         className={clsx([
-          stylesConfig.base,
           rounded && stylesConfig.rounded[rounded],
           error ? stylesConfig.state.error : stylesConfig.state.normal,
           disabled && stylesConfig.state.disabled,
@@ -82,12 +62,7 @@ const Input: FC<InputProps> = ({
         type={type}
         {...rest}
       />
-      {error && (
-        <p className="absolute -bottom-5.5 pl-3 text-sm text-tomato">
-          {errorText}
-        </p>
-      )}
-    </div>
+    </>
   );
 };
 

--- a/components/Input/Input.types.ts
+++ b/components/Input/Input.types.ts
@@ -1,0 +1,17 @@
+type RoundedInput = "sm" | "md" | "lg";
+
+export interface InputProps extends React.ComponentPropsWithoutRef<"input"> {
+  name?: string;
+  id?: string;
+  type?: string;
+  label?: string;
+  error?: boolean;
+  errorText?: string;
+  required?: boolean;
+  disabled?: boolean;
+  rounded?: RoundedInput;
+  placeholder?: string;
+  className?: string;
+  isBaseInput?: boolean;
+  fullWidth?: boolean;
+}

--- a/mocks/testMocks.ts
+++ b/mocks/testMocks.ts
@@ -1,6 +1,0 @@
-export const mockSessionWithUser = {
-  expires: new Date(Date.now() + 2 * 86400).toISOString(),
-  user: { name: "Test user", email: "test@example.com", id: "1" },
-};
-
-export const mockSessionWithNoUser = null;

--- a/mocks/testMocks.tsx
+++ b/mocks/testMocks.tsx
@@ -1,0 +1,75 @@
+import { Formik } from "formik";
+
+export const mockSessionWithUser = {
+  expires: new Date(Date.now() + 2 * 86400).toISOString(),
+  user: { name: "Test user", email: "test@example.com", id: "1" },
+};
+
+export const mockSessionWithNoUser = null;
+
+export const mockMeta = {
+  touched: true,
+  error: "",
+  initialError: "",
+  initialTouched: false,
+  initialValue: "",
+  value: "",
+};
+export const mockField = {
+  value: "",
+  checked: false,
+  onChange: jest.fn(),
+  onBlur: jest.fn(),
+  multiple: undefined,
+  name: "",
+};
+
+export const withFormikWrapper = (
+  WrappedComponent: JSX.Element,
+  initialValues: object
+): JSX.Element => (
+  <Formik
+    initialValues={initialValues ?? {}}
+    onSubmit={() => Promise.resolve()}
+  >
+    {WrappedComponent}
+  </Formik>
+);
+
+export const MOCK_FORMIK_INSTANCE = {
+  formikInstance: {
+    dirty: false,
+    values: jest.fn(),
+    touched: jest.fn(),
+    isSubmitting: false,
+    isValidating: false,
+    submitCount: 0,
+    errors: jest.fn(),
+    isValid: true,
+    initialValues: jest.fn(),
+    initialErrors: jest.fn(),
+    initialTouched: jest.fn(),
+    getFieldHelpers: jest.fn(),
+    getFieldMeta: jest.fn(),
+    getFieldProps: jest.fn(),
+    handleBlur: jest.fn(),
+    handleChange: jest.fn(),
+    handleReset: jest.fn(),
+    handleSubmit: jest.fn(),
+    setStatus: jest.fn(),
+    setErrors: jest.fn(),
+    setSubmitting: jest.fn(),
+    setTouched: jest.fn(),
+    setValues: jest.fn(),
+    setFieldValue: jest.fn(),
+    setFieldError: jest.fn(),
+    setFieldTouched: jest.fn(),
+    validateForm: jest.fn(),
+    validateField: jest.fn(),
+    resetForm: jest.fn(),
+    submitForm: jest.fn(),
+    setFormikState: jest.fn(),
+    registerField: jest.fn(),
+    unregisterField: jest.fn(),
+  },
+};

--- a/modules/auth/auth.configs.ts
+++ b/modules/auth/auth.configs.ts
@@ -1,0 +1,95 @@
+import { v4 as uuidv4 } from "uuid";
+
+import {
+  FormActionConfig,
+  FormActionConfigProps,
+  FromInputConfig,
+} from "./auth.types";
+
+export const SIGN_IN_FORM_INPUTS_CONFIG: FromInputConfig[] = [
+  {
+    id: uuidv4(),
+    name: "email",
+    placeholder: "Enter your email",
+    type: "email",
+    fullWidth: true,
+    label: "Email",
+  },
+  {
+    id: uuidv4(),
+    name: "password",
+    placeholder: "Enter your password",
+    type: "password",
+    fullWidth: true,
+    label: "Password",
+  },
+];
+
+export const SIGN_UP_FORM_INPUTS_CONFIG: FromInputConfig[] = [
+  {
+    id: uuidv4(),
+    name: "name",
+    placeholder: "Enter your name",
+    fullWidth: true,
+  },
+  ...SIGN_IN_FORM_INPUTS_CONFIG.map((input) => ({
+    ...input,
+    label: "",
+  })),
+  {
+    id: uuidv4(),
+    name: "confirmedPassword",
+    placeholder: "Confirm the password",
+    type: "password",
+    fullWidth: true,
+  },
+];
+
+export const FORM_ACTIONS_CONFIG = ({
+  isSignUpForm,
+  onSubmitWithCredentials,
+  onSubmitWithGithub,
+  onSubmitWithGoogle,
+}: FormActionConfigProps): FormActionConfig[] => {
+  const signInWithCredentialsConfig: FormActionConfig[] = [
+    {
+      id: uuidv4(),
+      label: "Create a new user with credentials",
+      variant: "primary",
+      className: "mb-3",
+      fullWidth: true,
+      onClick: onSubmitWithCredentials,
+    },
+  ];
+
+  if (isSignUpForm) {
+    return signInWithCredentialsConfig;
+  }
+
+  return [
+    {
+      id: uuidv4(),
+      label: "Sign-In with Credentials",
+      variant: "primary",
+      className: "mb-3",
+      fullWidth: true,
+      onClick: onSubmitWithCredentials,
+    },
+    {
+      id: uuidv4(),
+      label: "Sign-In with Github",
+      variant: "secondary",
+      className: "mb-3",
+      fullWidth: true,
+      onClick: onSubmitWithGithub,
+    },
+    {
+      id: uuidv4(),
+      label: "Sign-In with Google",
+      variant: "tertiary",
+      className: "mb-3",
+      fullWidth: true,
+      onClick: onSubmitWithGoogle,
+    },
+  ];
+};

--- a/modules/auth/auth.constants.ts
+++ b/modules/auth/auth.constants.ts
@@ -15,3 +15,4 @@ export const SIGN_UP_FORM_HEADER_SUBTITLE =
   '"I am gonna make him an offer he can not refuse."" - The Godfather (1972)';
 export const SIGN_IN_FORM_REDIRECTION_LINK = "Do not have an account?";
 export const SIGN_UP_FORM_REDIRECTION_LINK = "Already have have an account?";
+export const SIGN_UP_SUCCESSFUL_MESSAGE = "Successfully signed out";

--- a/modules/auth/auth.types.ts
+++ b/modules/auth/auth.types.ts
@@ -1,0 +1,91 @@
+import { FormikHelpers } from "formik";
+
+import { ButtonVariant } from "@/components/Button/Button.types";
+
+export interface SignInFormInitialValues {
+  email: string;
+  password: string;
+}
+
+export interface SignUpFormInitialValues {
+  name?: string;
+  email: string;
+  password: string;
+  confirmedPassword: string;
+}
+
+export type AuthFormInitialValues =
+  | SignInFormInitialValues
+  | SignUpFormInitialValues;
+
+export interface FromInputConfig {
+  fullWidth?: boolean;
+  id: string;
+  name: string;
+  placeholder: string;
+  type?: string;
+  label?: string;
+}
+
+export type ButtonClick = (
+  e: React.MouseEvent<HTMLButtonElement, MouseEvent>
+) => void | Promise<void>;
+
+export interface FormActionConfig {
+  id: string;
+  label: string;
+  variant: ButtonVariant;
+  fullWidth?: boolean;
+  className?: string;
+  onClick?: ButtonClick;
+}
+
+export interface FormActionConfigProps {
+  isSignUpForm?: boolean;
+  onSubmitWithCredentials?: () => Promise<void>;
+  onSubmitWithGithub?: (
+    e: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => void;
+  onSubmitWithGoogle?: (
+    e: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => void;
+}
+
+export interface FormActionsProps extends FormActionConfigProps {
+  route: string;
+  title: string;
+  isDisabled?: boolean;
+}
+
+export interface HookReturnedType {
+  onSignInViaGithub: () => Promise<void>;
+  onSignInViaGoogle: () => Promise<void>;
+  onSignInViaEmailAndPassword: (
+    email: string,
+    password: string
+  ) => Promise<void>;
+  onCreateNewUser: ({
+    name,
+    email,
+    password,
+  }: {
+    name?: string;
+    email: string;
+    password: string;
+  }) => Promise<void>;
+  onSignOut: () => Promise<void>;
+  onSubmitFormWithCredentials: (
+    values: SignInFormInitialValues,
+    helpers: FormikHelpers<SignInFormInitialValues>
+  ) => Promise<void>;
+  onSubmitFormAndCreateNewUser: (
+    values: SignUpFormInitialValues,
+    helpers: FormikHelpers<SignUpFormInitialValues>
+  ) => Promise<void>;
+  onSubmitFormViaGithub: (
+    e: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => void;
+  onSubmitFormViaGoogle: (
+    e: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => void;
+}

--- a/modules/auth/components/FormActions/FormActions.tsx
+++ b/modules/auth/components/FormActions/FormActions.tsx
@@ -1,0 +1,56 @@
+import React, { FC, memo, useMemo } from "react";
+
+import Button from "@/components/Button";
+
+import { FormActionConfig, FormActionsProps } from "./../../auth.types";
+import { FORM_ACTIONS_CONFIG } from "../../auth.configs";
+import FormRedirectLink from "../FormRedirectLink";
+
+const FormActions: FC<FormActionsProps> = ({
+  isSignUpForm = false,
+  isDisabled = false,
+  route,
+  title,
+  onSubmitWithCredentials,
+  onSubmitWithGithub,
+  onSubmitWithGoogle,
+}) => {
+  const actionButtonsConfig: FormActionConfig[] = useMemo(
+    () =>
+      FORM_ACTIONS_CONFIG({
+        isSignUpForm,
+        onSubmitWithCredentials,
+        onSubmitWithGithub,
+        onSubmitWithGoogle,
+      }),
+    [
+      isSignUpForm,
+      onSubmitWithCredentials,
+      onSubmitWithGithub,
+      onSubmitWithGoogle,
+    ]
+  );
+  return (
+    <div className="flex flex-col mt-5">
+      {actionButtonsConfig.map((button) => {
+        const { id, label, variant, className, fullWidth, onClick } = button;
+
+        return (
+          <Button
+            key={id}
+            className={className}
+            disabled={variant === "primary" && isDisabled}
+            fullWidth={fullWidth}
+            variant={variant}
+            onClick={onClick}
+          >
+            {label}
+          </Button>
+        );
+      })}
+      <FormRedirectLink route={route} title={title} />
+    </div>
+  );
+};
+
+export default memo(FormActions);

--- a/modules/auth/components/FormActions/index.ts
+++ b/modules/auth/components/FormActions/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./FormActions";

--- a/modules/auth/components/FormHeader/FormHeader.tsx
+++ b/modules/auth/components/FormHeader/FormHeader.tsx
@@ -8,7 +8,7 @@ interface FormHeaderProps {
 
 const FormHeader: FC<FormHeaderProps> = ({ title, subtitle = "" }) => {
   return (
-    <div className="flex flex-col items-center mb-5 border-b-2 border-mantisDarker pb-2.5">
+    <div className="flex flex-col items-center mb-5 border-b-2 border-white pb-2.5 lg:border-mantisDarker">
       <h3
         className={clsx("text-lg font-medium uppercase", [
           subtitle ? "mb-2" : "mb-0",

--- a/modules/auth/components/FormInputs/FormInputs.tsx
+++ b/modules/auth/components/FormInputs/FormInputs.tsx
@@ -1,0 +1,33 @@
+import React, { FC, memo } from "react";
+
+import FormikInput from "@/components/Input/FormikInput";
+
+import { FromInputConfig } from "../../auth.types";
+
+interface FormInputsProps {
+  config: FromInputConfig[];
+}
+
+const FormInputs: FC<FormInputsProps> = ({ config }) => {
+  return (
+    <>
+      {config.map((input) => {
+        const { id, name, placeholder, fullWidth, label, type } = input;
+
+        return (
+          <FormikInput
+            key={id}
+            fullWidth={fullWidth}
+            id={name}
+            label={label}
+            name={name}
+            placeholder={placeholder}
+            type={type}
+          />
+        );
+      })}
+    </>
+  );
+};
+
+export default memo(FormInputs);

--- a/modules/auth/components/FormInputs/index.ts
+++ b/modules/auth/components/FormInputs/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./FormInputs";

--- a/modules/auth/components/SignIn/SignIn.schema.ts
+++ b/modules/auth/components/SignIn/SignIn.schema.ts
@@ -1,0 +1,14 @@
+import * as yup from "yup";
+
+import { SignInFormInitialValues } from "../../auth.types";
+
+export const SIGN_IN_FORM_INITIAL_VALUE: SignInFormInitialValues = {
+  email: "",
+  password: "",
+};
+
+export const SIGN_IN_FORM_VALIDATION: yup.SchemaOf<SignInFormInitialValues> =
+  yup.object().shape({
+    email: yup.string().email().label("Email").required(),
+    password: yup.string().label("Password").required().trim(),
+  });

--- a/modules/auth/components/SignIn/SignIn.tsx
+++ b/modules/auth/components/SignIn/SignIn.tsx
@@ -1,57 +1,31 @@
-import { useFormik } from "formik";
+import { Form, Formik } from "formik";
 import { FC } from "react";
 
-import Button from "@/components/Button";
-import Input from "@/components/Input";
-import AuthLayout from "@/modules/layout/AuthLayout";
 import {
   SIGN_IN_FORM_HEADER_SUBTITLE,
   SIGN_IN_FORM_HEADER_TITLE,
   SIGN_IN_FORM_REDIRECTION_LINK,
-} from "@/types/constants";
+} from "@/modules/auth/auth.constants";
+import AuthLayout from "@/modules/layout/AuthLayout";
 import { AppRoutes } from "@/types/enums";
 
+import {
+  SIGN_IN_FORM_INITIAL_VALUE,
+  SIGN_IN_FORM_VALIDATION,
+} from "./SignIn.schema";
 import SignInImage from "../../../../public/assets/auth-layout/sign-in-bg.jpg";
+import { SIGN_IN_FORM_INPUTS_CONFIG } from "../../auth.configs";
 import useAuth from "../../hooks/useAuth";
+import FormActions from "../FormActions";
 import FormHeader from "../FormHeader";
-import FormRedirectLink from "../FormRedirectLink";
-
-type FormInitialValues = {
-  email: string;
-  password: string;
-};
+import FormInputs from "../FormInputs";
 
 const SignIn: FC = () => {
-  const { onSignInViaGithub, onSignInViaEmailAndPAssword, onSignInViaGoogle } =
-    useAuth();
-
-  const formik = useFormik<FormInitialValues>({
-    initialValues: {
-      email: "",
-      password: "",
-    },
-    onSubmit: (values) => handleSubmitWithCredentials(values),
-  });
-
-  function handleSignInViaGithub(
-    e: React.MouseEvent<HTMLButtonElement, MouseEvent>
-  ): void {
-    e.preventDefault();
-
-    onSignInViaGithub();
-  }
-
-  function handleSubmitWithCredentials(values: FormInitialValues): void {
-    onSignInViaEmailAndPAssword(values.email, values.password);
-  }
-
-  function handleSignInViaGoogle(
-    e: React.MouseEvent<HTMLButtonElement, MouseEvent>
-  ) {
-    e.preventDefault();
-
-    onSignInViaGoogle();
-  }
+  const {
+    onSubmitFormWithCredentials,
+    onSubmitFormViaGithub,
+    onSubmitFormViaGoogle,
+  } = useAuth();
 
   return (
     <AuthLayout
@@ -59,52 +33,31 @@ const SignIn: FC = () => {
       image={SignInImage}
       layout="fill"
     >
-      <form className="form" onSubmit={formik.handleSubmit}>
-        <FormHeader
-          subtitle={SIGN_IN_FORM_HEADER_SUBTITLE}
-          title={SIGN_IN_FORM_HEADER_TITLE}
-        />
-        <Input
-          fullWidth
-          required
-          label="Email"
-          type="email"
-          {...formik.getFieldProps("email")}
-          placeholder="Enter your email"
-        />
-        <Input
-          fullWidth
-          label="Password"
-          type="password"
-          {...formik.getFieldProps("password")}
-          placeholder="Enter your password"
-        />
-        <div className="flex flex-col mt-5">
-          <Button fullWidth className="mb-3" type="submit" variant="primary">
-            Sign-In with Credentials
-          </Button>
-          <Button
-            fullWidth
-            className="mb-3"
-            variant="secondary"
-            onClick={(e) => handleSignInViaGithub(e)}
-          >
-            Sign-In with Github
-          </Button>
-          <Button
-            fullWidth
-            className="mb-3"
-            variant="tertiary"
-            onClick={(e) => handleSignInViaGoogle(e)}
-          >
-            Sign-In with Google
-          </Button>
-          <FormRedirectLink
-            route={AppRoutes.SignUp}
-            title={SIGN_IN_FORM_REDIRECTION_LINK}
-          />
-        </div>
-      </form>
+      <Formik
+        initialValues={SIGN_IN_FORM_INITIAL_VALUE}
+        validationSchema={SIGN_IN_FORM_VALIDATION}
+        onSubmit={onSubmitFormWithCredentials}
+      >
+        {({ submitForm, isSubmitting, errors }) => {
+          return (
+            <Form className="form">
+              <FormHeader
+                subtitle={SIGN_IN_FORM_HEADER_SUBTITLE}
+                title={SIGN_IN_FORM_HEADER_TITLE}
+              />
+              <FormInputs config={SIGN_IN_FORM_INPUTS_CONFIG} />
+              <FormActions
+                isDisabled={isSubmitting || Object.keys(errors).length > 0}
+                route={AppRoutes.SignUp}
+                title={SIGN_IN_FORM_REDIRECTION_LINK}
+                onSubmitWithCredentials={submitForm}
+                onSubmitWithGithub={onSubmitFormViaGithub}
+                onSubmitWithGoogle={onSubmitFormViaGoogle}
+              />
+            </Form>
+          );
+        }}
+      </Formik>
     </AuthLayout>
   );
 };

--- a/modules/auth/components/SignUp/SignUp.schema.ts
+++ b/modules/auth/components/SignUp/SignUp.schema.ts
@@ -1,0 +1,31 @@
+import * as yup from "yup";
+
+import { SignUpFormInitialValues } from "../../auth.types";
+
+export const SIGN_UP_FORM_INITIAL_VALUE: SignUpFormInitialValues = {
+  name: "",
+  email: "",
+  password: "",
+  confirmedPassword: "",
+};
+
+export const SIGN_UP_FORM_VALIDATION: yup.SchemaOf<SignUpFormInitialValues> =
+  yup.object().shape({
+    name: yup.string().label("Name"),
+    email: yup.string().email().label("Email").required(),
+    password: yup
+      .string()
+      .label("Password")
+      .required()
+      .min(8, "Should be at least 8 characters")
+      .matches(/[a-z]+/, "One lowercase character")
+      .matches(/[A-Z]+/, "One uppercase character")
+      .matches(/[@$!%*#?&]+/, "One special character")
+      .matches(/\d+/, "One number"),
+    confirmedPassword: yup
+      .string()
+      .label("Confirm Password")
+      .oneOf([yup.ref("password"), null], "Passwords must match")
+      .required()
+      .trim(),
+  });

--- a/modules/auth/components/SignUp/SignUp.tsx
+++ b/modules/auth/components/SignUp/SignUp.tsx
@@ -1,46 +1,27 @@
-import { useFormik } from "formik";
+import { Form, Formik } from "formik";
 import { FC } from "react";
 
-import Button from "@/components/Button";
-import Input from "@/components/Input";
-import AuthLayout from "@/modules/layout/AuthLayout";
 import {
   SIGN_UP_FORM_HEADER_SUBTITLE,
   SIGN_UP_FORM_HEADER_TITLE,
   SIGN_UP_FORM_REDIRECTION_LINK,
-} from "@/types/constants";
+} from "@/modules/auth/auth.constants";
+import AuthLayout from "@/modules/layout/AuthLayout";
 import { AppRoutes } from "@/types/enums";
 
+import {
+  SIGN_UP_FORM_INITIAL_VALUE,
+  SIGN_UP_FORM_VALIDATION,
+} from "./SignUp.schema";
 import SignUpImage from "../../../../public/assets/auth-layout/sign-up-bg.webp";
+import { SIGN_UP_FORM_INPUTS_CONFIG } from "../../auth.configs";
 import useAuth from "../../hooks/useAuth";
+import FormActions from "../FormActions";
 import FormHeader from "../FormHeader";
-import FormRedirectLink from "../FormRedirectLink";
-
-type FormInitialValues = {
-  name: string;
-  email: string;
-  password: string;
-  confirmPassword: string;
-};
+import FormInputs from "../FormInputs";
 
 const SignUp: FC = () => {
-  const { onCreateNewUser } = useAuth();
-
-  const formik = useFormik<FormInitialValues>({
-    initialValues: {
-      name: "",
-      email: "",
-      password: "",
-      confirmPassword: "",
-    },
-    onSubmit: (values) => handleSubmitWithCredentials(values),
-  });
-
-  function handleSubmitWithCredentials(values: FormInitialValues): void {
-    const { name, email, password } = values;
-
-    onCreateNewUser({ name, email, password });
-  }
+  const { onSubmitFormAndCreateNewUser } = useAuth();
 
   return (
     <AuthLayout
@@ -48,47 +29,28 @@ const SignUp: FC = () => {
       image={SignUpImage}
       layout="fill"
     >
-      <form className="form" onSubmit={formik.handleSubmit}>
-        <FormHeader
-          subtitle={SIGN_UP_FORM_HEADER_SUBTITLE}
-          title={SIGN_UP_FORM_HEADER_TITLE}
-        />
-        <Input
-          {...formik.getFieldProps("name")}
-          fullWidth
-          placeholder="Enter your name"
-        />
-        <Input
-          required
-          type="email"
-          {...formik.getFieldProps("email")}
-          fullWidth
-          placeholder="Enter your email"
-        />
-        <Input
-          required
-          type="password"
-          {...formik.getFieldProps("password")}
-          fullWidth
-          placeholder="Enter your password"
-        />
-        <Input
-          required
-          type="password"
-          {...formik.getFieldProps("confirmPassword")}
-          fullWidth
-          placeholder="Confirm password"
-        />
-        <div className="flex flex-col mt-5">
-          <Button fullWidth className="mb-3" type="submit" value="primary">
-            Create a new user with credentials
-          </Button>
-          <FormRedirectLink
-            route={AppRoutes.SignIn}
-            title={SIGN_UP_FORM_REDIRECTION_LINK}
-          />
-        </div>
-      </form>
+      <Formik
+        initialValues={SIGN_UP_FORM_INITIAL_VALUE}
+        validationSchema={SIGN_UP_FORM_VALIDATION}
+        onSubmit={onSubmitFormAndCreateNewUser}
+      >
+        {({ submitForm, isSubmitting, errors }) => (
+          <Form className="form">
+            <FormHeader
+              subtitle={SIGN_UP_FORM_HEADER_SUBTITLE}
+              title={SIGN_UP_FORM_HEADER_TITLE}
+            />
+            <FormInputs config={SIGN_UP_FORM_INPUTS_CONFIG} />
+            <FormActions
+              isSignUpForm
+              isDisabled={isSubmitting || Object.keys(errors).length > 0}
+              route={AppRoutes.SignIn}
+              title={SIGN_UP_FORM_REDIRECTION_LINK}
+              onSubmitWithCredentials={submitForm}
+            />
+          </Form>
+        )}
+      </Formik>
     </AuthLayout>
   );
 };

--- a/modules/auth/hooks/useAuth.tsx
+++ b/modules/auth/hooks/useAuth.tsx
@@ -1,34 +1,23 @@
+import { FormikHelpers } from "formik";
 import { useRouter } from "next/dist/client/router";
 import { signIn, signOut } from "next-auth/react";
 import fetch from "node-fetch";
 
-import { toastService } from "@/services/toast.service";
 import {
+  SIGN_UP_SUCCESSFUL_MESSAGE,
   SUCCESSFULLY_CREATED_USER_MESSAGE,
   SUCCESSFULLY_SIGNED_IN_WITH_CREDENTIALS_MESSAGE,
   USERNAME_OR_PASSWORD_DOES_NOT_MATCH_MESSAGE,
   USER_ALREADY_EXIST_MESSAGE,
-} from "@/types/constants";
+} from "@/modules/auth/auth.constants";
+import { toastService } from "@/services/toast.service";
 import { AppRoutes } from "@/types/enums";
 
-interface HookReturnedType {
-  onSignInViaGithub: () => Promise<void>;
-  onSignInViaGoogle: () => Promise<void>;
-  onSignInViaEmailAndPAssword: (
-    email: string,
-    password: string
-  ) => Promise<void>;
-  onCreateNewUser: ({
-    name,
-    email,
-    password,
-  }: {
-    name: string;
-    email: string;
-    password: string;
-  }) => Promise<void>;
-  onSignOut: () => Promise<void>;
-}
+import {
+  HookReturnedType,
+  SignInFormInitialValues,
+  SignUpFormInitialValues,
+} from "../auth.types";
 
 const useAuth = (): HookReturnedType => {
   const router = useRouter();
@@ -71,7 +60,7 @@ const useAuth = (): HookReturnedType => {
     email,
     password,
   }: {
-    name: string;
+    name?: string;
     email: string;
     password: string;
   }): Promise<void> {
@@ -116,19 +105,57 @@ const useAuth = (): HookReturnedType => {
 
       if (data.url) {
         router.push(data.url);
-        toastService.success("Successfully signed out");
+        toastService.success(SIGN_UP_SUCCESSFUL_MESSAGE);
       }
     } catch (err) {
       toastService.error((err as Error).message);
     }
   }
 
+  async function onSubmitFormWithCredentials(
+    values: SignInFormInitialValues,
+    helpers: FormikHelpers<SignInFormInitialValues>
+  ): Promise<void> {
+    await onSignInViaEmailAndPassword(values.email, values.password);
+    helpers.resetForm({ values });
+  }
+
+  async function onSubmitFormAndCreateNewUser(
+    values: SignUpFormInitialValues,
+    helpers: FormikHelpers<SignUpFormInitialValues>
+  ): Promise<void> {
+    const { name, email, password } = values;
+
+    await onCreateNewUser({ name, email, password });
+    helpers.resetForm({ values });
+  }
+
+  function onSubmitFormViaGithub(
+    e: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ): void {
+    e.preventDefault();
+
+    onSignInViaGithub();
+  }
+
+  function onSubmitFormViaGoogle(
+    e: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) {
+    e.preventDefault();
+
+    onSignInViaGoogle();
+  }
+
   return {
     onSignInViaGithub,
     onSignInViaGoogle,
-    onSignInViaEmailAndPAssword: onSignInViaEmailAndPassword,
+    onSignInViaEmailAndPassword,
     onCreateNewUser,
     onSignOut,
+    onSubmitFormWithCredentials,
+    onSubmitFormAndCreateNewUser,
+    onSubmitFormViaGithub,
+    onSubmitFormViaGoogle,
   };
 };
 

--- a/pages/api/auth/sign-up.ts
+++ b/pages/api/auth/sign-up.ts
@@ -7,7 +7,7 @@ import {
   NO_DATA_IN_REQUEST_BODY_MESSAGE,
   SUCCESSFULLY_CREATED_USER_MESSAGE,
   USER_ALREADY_EXIST_MESSAGE,
-} from "@/types/constants";
+} from "@/modules/auth/auth.constants";
 import { RequestMethod } from "@/types/enums";
 import { CreateUser, UpdateExistingUser } from "@/types/interfaces";
 import { convertResponseErrorMessageToCorrectFormat } from "@/utils/utils";

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -44,13 +44,13 @@ img {
 
 @layer components {
   .auth-layout {
-    @apply relative m-auto bg-darkBlue rounded-md border-4 border-mantis w-11/12 h-4/5 grid sm:h-4/6 md:w-4/5;
+    @apply relative m-auto bg-darkBlue rounded-md border-4 border-mantis w-11/12 h-4/5 grid;
 
     @screen lg {
       grid-template-columns: repeat(2, minmax(0, 1fr));
       gap: 1.2rem;
       width: 75%;
-      height: 75%;
+      height: auto;
     }
   }
 
@@ -71,7 +71,7 @@ img {
   }
 
   .auth-layout-img-overlay {
-    @apply absolute top-0 left-0 right-0 bottom-0 z-10 bg-gradient-to-br from-transparentMantisDarker2 to-transparentMantisDarker1;
+    @apply absolute top-0 left-0 right-0 bottom-0 z-10 bg-gradient-to-br from-transparentMantisDarker2 to-transparentMantisDarker2;
 
     @screen lg {
       background-image: linear-gradient(to bottom right, theme(colors.fadedBlack1), theme(colors.fadedBlack2));

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -110,7 +110,7 @@ module.exports = {
       mantis: "#7ac142",
       mantisDarker: " #5a803d",
       transparentMantisDarker1: "rgba(90, 128, 61, 0.3)",
-      transparentMantisDarker2: "rgba(90, 128, 61, 0.5)",
+      transparentMantisDarker2: "rgba(90, 128, 61, 0.7)",
       fadedBlack1: "rgba(0, 0, 0, 0.7)",
       fadedBlack2: "rgba(0, 0, 0, 0.4)",
       lighterBlue: "#153c6b",


### PR DESCRIPTION
- Implement Sign-in/Sign-up forms validations with Yup
- Refactor Sign-in/Sign-up forms
- Move Inputs and buttons rendering to configs
- Adjust Input to be reusable with FormikInput
- Update existing tests and cover new codebase with new tests