### PR TITLE
Add See More button to all sliders, connect the See More page of each slide within the Home page with API to get corresponding data

### DIFF
--- a/__test__/pages/home/now-playing/index.test.tsx
+++ b/__test__/pages/home/now-playing/index.test.tsx
@@ -1,0 +1,81 @@
+import { screen } from "@testing-library/react";
+import { GetServerSidePropsContext } from "next";
+import { QueryObserverSuccessResult } from "react-query";
+import * as hooks from "react-query";
+
+import {
+  mockMovie,
+  mockSessionWithUser,
+  withQueryClientProvider,
+} from "@/mocks/testMocks";
+import { homePageService } from "@/modules/home/home.service";
+import { getServerSideProps } from "@/pages/home/index";
+import NowPlayingMoviesPage from "@/pages/home/now-playing";
+import * as utils from "@/utils/utils";
+
+jest.mock("react-query", () => {
+  const originalModule = jest.requireActual("react-query");
+
+  return {
+    ...originalModule,
+    useQuery: jest.fn(),
+  };
+});
+
+jest.mock("uuid", () => {
+  return {
+    v4: jest.fn(() => 1),
+  };
+});
+
+global.fetch = jest.fn(() =>
+  Promise.resolve({
+    json: () =>
+      Promise.resolve({
+        user: { name: "John Doe", email: "john@doe.com" },
+        password: "12456",
+      }),
+  })
+);
+
+jest.mock("@/hooks/useGetRandomMovieOrSerial");
+
+describe("NowPlayingMoviesPage", () => {
+  beforeEach(() => {
+    jest.spyOn(hooks, "useQuery").mockReturnValue({
+      data: {
+        popularMovies: {
+          results: [mockMovie],
+        },
+      },
+    } as unknown as QueryObserverSuccessResult<unknown, unknown>);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("Should render component without crashing", () => {
+    withQueryClientProvider(<NowPlayingMoviesPage />);
+
+    expect(screen.getByText(/NowPlayingPage/)).toBeInTheDocument();
+  });
+
+  it("Should trigger getServerSideProps and called fetchMoviesForHomePage method within homePageService", async () => {
+    const fetchMoviesForHomePageMock = jest.spyOn(
+      homePageService,
+      "fetchMoviesForHomePage"
+    );
+    const prefetchMovieOrSerialDataMock = jest.spyOn(
+      utils,
+      "prefetchMovieOrSerialData"
+    );
+
+    getServerSideProps({
+      session: mockSessionWithUser,
+    } as unknown as GetServerSidePropsContext);
+
+    expect(prefetchMovieOrSerialDataMock).toHaveBeenCalled();
+    expect(fetchMoviesForHomePageMock).toHaveBeenCalled();
+  });
+});

--- a/__test__/pages/home/popular/index.test.tsx
+++ b/__test__/pages/home/popular/index.test.tsx
@@ -1,0 +1,81 @@
+import { screen } from "@testing-library/react";
+import { GetServerSidePropsContext } from "next";
+import { QueryObserverSuccessResult } from "react-query";
+import * as hooks from "react-query";
+
+import {
+  mockMovie,
+  mockSessionWithUser,
+  withQueryClientProvider,
+} from "@/mocks/testMocks";
+import { homePageService } from "@/modules/home/home.service";
+import { getServerSideProps } from "@/pages/home/index";
+import PopularMoviesPage from "@/pages/home/popular";
+import * as utils from "@/utils/utils";
+
+jest.mock("react-query", () => {
+  const originalModule = jest.requireActual("react-query");
+
+  return {
+    ...originalModule,
+    useQuery: jest.fn(),
+  };
+});
+
+jest.mock("uuid", () => {
+  return {
+    v4: jest.fn(() => 1),
+  };
+});
+
+global.fetch = jest.fn(() =>
+  Promise.resolve({
+    json: () =>
+      Promise.resolve({
+        user: { name: "John Doe", email: "john@doe.com" },
+        password: "12456",
+      }),
+  })
+);
+
+jest.mock("@/hooks/useGetRandomMovieOrSerial");
+
+describe("PopularMoviesPage", () => {
+  beforeEach(() => {
+    jest.spyOn(hooks, "useQuery").mockReturnValue({
+      data: {
+        popularMovies: {
+          results: [mockMovie],
+        },
+      },
+    } as unknown as QueryObserverSuccessResult<unknown, unknown>);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("Should render component without crashing", () => {
+    withQueryClientProvider(<PopularMoviesPage />);
+
+    expect(screen.getByText(/PopularMoviesPage/)).toBeInTheDocument();
+  });
+
+  it("Should trigger getServerSideProps and called fetchMoviesForHomePage method within homePageService", async () => {
+    const fetchMoviesForHomePageMock = jest.spyOn(
+      homePageService,
+      "fetchMoviesForHomePage"
+    );
+    const prefetchMovieOrSerialDataMock = jest.spyOn(
+      utils,
+      "prefetchMovieOrSerialData"
+    );
+
+    getServerSideProps({
+      session: mockSessionWithUser,
+    } as unknown as GetServerSidePropsContext);
+
+    expect(prefetchMovieOrSerialDataMock).toHaveBeenCalled();
+    expect(fetchMoviesForHomePageMock).toHaveBeenCalled();
+  });
+});

--- a/__test__/pages/home/top-rated/index.test.tsx
+++ b/__test__/pages/home/top-rated/index.test.tsx
@@ -1,0 +1,81 @@
+import { screen } from "@testing-library/react";
+import { GetServerSidePropsContext } from "next";
+import { QueryObserverSuccessResult } from "react-query";
+import * as hooks from "react-query";
+
+import {
+  mockMovie,
+  mockSessionWithUser,
+  withQueryClientProvider,
+} from "@/mocks/testMocks";
+import { homePageService } from "@/modules/home/home.service";
+import { getServerSideProps } from "@/pages/home/index";
+import TopRatedMoviesPage from "@/pages/home/top-rated";
+import * as utils from "@/utils/utils";
+
+jest.mock("react-query", () => {
+  const originalModule = jest.requireActual("react-query");
+
+  return {
+    ...originalModule,
+    useQuery: jest.fn(),
+  };
+});
+
+jest.mock("uuid", () => {
+  return {
+    v4: jest.fn(() => 1),
+  };
+});
+
+global.fetch = jest.fn(() =>
+  Promise.resolve({
+    json: () =>
+      Promise.resolve({
+        user: { name: "John Doe", email: "john@doe.com" },
+        password: "12456",
+      }),
+  })
+);
+
+jest.mock("@/hooks/useGetRandomMovieOrSerial");
+
+describe("TopRatedMoviesPage", () => {
+  beforeEach(() => {
+    jest.spyOn(hooks, "useQuery").mockReturnValue({
+      data: {
+        popularMovies: {
+          results: [mockMovie],
+        },
+      },
+    } as unknown as QueryObserverSuccessResult<unknown, unknown>);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("Should render component without crashing", () => {
+    withQueryClientProvider(<TopRatedMoviesPage />);
+
+    expect(screen.getByText(/TopRatedMoviesPage/)).toBeInTheDocument();
+  });
+
+  it("Should trigger getServerSideProps and called fetchMoviesForHomePage method within homePageService", async () => {
+    const fetchMoviesForHomePageMock = jest.spyOn(
+      homePageService,
+      "fetchMoviesForHomePage"
+    );
+    const prefetchMovieOrSerialDataMock = jest.spyOn(
+      utils,
+      "prefetchMovieOrSerialData"
+    );
+
+    getServerSideProps({
+      session: mockSessionWithUser,
+    } as unknown as GetServerSidePropsContext);
+
+    expect(prefetchMovieOrSerialDataMock).toHaveBeenCalled();
+    expect(fetchMoviesForHomePageMock).toHaveBeenCalled();
+  });
+});

--- a/__test__/pages/home/trending/index.test.tsx
+++ b/__test__/pages/home/trending/index.test.tsx
@@ -1,0 +1,81 @@
+import { screen } from "@testing-library/react";
+import { GetServerSidePropsContext } from "next";
+import { QueryObserverSuccessResult } from "react-query";
+import * as hooks from "react-query";
+
+import {
+  mockMovie,
+  mockSessionWithUser,
+  withQueryClientProvider,
+} from "@/mocks/testMocks";
+import { homePageService } from "@/modules/home/home.service";
+import { getServerSideProps } from "@/pages/home/index";
+import TrendingMoviesPage from "@/pages/home/trending";
+import * as utils from "@/utils/utils";
+
+jest.mock("react-query", () => {
+  const originalModule = jest.requireActual("react-query");
+
+  return {
+    ...originalModule,
+    useQuery: jest.fn(),
+  };
+});
+
+jest.mock("uuid", () => {
+  return {
+    v4: jest.fn(() => 1),
+  };
+});
+
+global.fetch = jest.fn(() =>
+  Promise.resolve({
+    json: () =>
+      Promise.resolve({
+        user: { name: "John Doe", email: "john@doe.com" },
+        password: "12456",
+      }),
+  })
+);
+
+jest.mock("@/hooks/useGetRandomMovieOrSerial");
+
+describe("TrendingMoviesPage", () => {
+  beforeEach(() => {
+    jest.spyOn(hooks, "useQuery").mockReturnValue({
+      data: {
+        popularMovies: {
+          results: [mockMovie],
+        },
+      },
+    } as unknown as QueryObserverSuccessResult<unknown, unknown>);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("Should render component without crashing", () => {
+    withQueryClientProvider(<TrendingMoviesPage />);
+
+    expect(screen.getByText(/TrendingMoviesPage/)).toBeInTheDocument();
+  });
+
+  it("Should trigger getServerSideProps and called fetchMoviesForHomePage method within homePageService", async () => {
+    const fetchMoviesForHomePageMock = jest.spyOn(
+      homePageService,
+      "fetchMoviesForHomePage"
+    );
+    const prefetchMovieOrSerialDataMock = jest.spyOn(
+      utils,
+      "prefetchMovieOrSerialData"
+    );
+
+    getServerSideProps({
+      session: mockSessionWithUser,
+    } as unknown as GetServerSidePropsContext);
+
+    expect(prefetchMovieOrSerialDataMock).toHaveBeenCalled();
+    expect(fetchMoviesForHomePageMock).toHaveBeenCalled();
+  });
+});

--- a/__test__/pages/home/upcoming/index.test.tsx
+++ b/__test__/pages/home/upcoming/index.test.tsx
@@ -1,0 +1,81 @@
+import { screen } from "@testing-library/react";
+import { GetServerSidePropsContext } from "next";
+import { QueryObserverSuccessResult } from "react-query";
+import * as hooks from "react-query";
+
+import {
+  mockMovie,
+  mockSessionWithUser,
+  withQueryClientProvider,
+} from "@/mocks/testMocks";
+import { homePageService } from "@/modules/home/home.service";
+import { getServerSideProps } from "@/pages/home/index";
+import UpcomingMoviesPage from "@/pages/home/upcoming";
+import * as utils from "@/utils/utils";
+
+jest.mock("react-query", () => {
+  const originalModule = jest.requireActual("react-query");
+
+  return {
+    ...originalModule,
+    useQuery: jest.fn(),
+  };
+});
+
+jest.mock("uuid", () => {
+  return {
+    v4: jest.fn(() => 1),
+  };
+});
+
+global.fetch = jest.fn(() =>
+  Promise.resolve({
+    json: () =>
+      Promise.resolve({
+        user: { name: "John Doe", email: "john@doe.com" },
+        password: "12456",
+      }),
+  })
+);
+
+jest.mock("@/hooks/useGetRandomMovieOrSerial");
+
+describe("UpcomingMoviesPage", () => {
+  beforeEach(() => {
+    jest.spyOn(hooks, "useQuery").mockReturnValue({
+      data: {
+        popularMovies: {
+          results: [mockMovie],
+        },
+      },
+    } as unknown as QueryObserverSuccessResult<unknown, unknown>);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("Should render component without crashing", () => {
+    withQueryClientProvider(<UpcomingMoviesPage />);
+
+    expect(screen.getByText(/UpcomingMoviesPage/)).toBeInTheDocument();
+  });
+
+  it("Should trigger getServerSideProps and called fetchMoviesForHomePage method within homePageService", async () => {
+    const fetchMoviesForHomePageMock = jest.spyOn(
+      homePageService,
+      "fetchMoviesForHomePage"
+    );
+    const prefetchMovieOrSerialDataMock = jest.spyOn(
+      utils,
+      "prefetchMovieOrSerialData"
+    );
+
+    getServerSideProps({
+      session: mockSessionWithUser,
+    } as unknown as GetServerSidePropsContext);
+
+    expect(prefetchMovieOrSerialDataMock).toHaveBeenCalled();
+    expect(fetchMoviesForHomePageMock).toHaveBeenCalled();
+  });
+});

--- a/components/Button/Button.tsx
+++ b/components/Button/Button.tsx
@@ -18,7 +18,7 @@ const Button: FC<ButtonProps> = ({
   const stylesConfig = {
     base: "flex items-center justify-center focus:outline-none transition ease-in-out duration-300",
     size: {
-      small: "px-2 py-1 text-sm",
+      small: "px-2.5 py-1.5 text-sm",
       normal: "px-4 py-2",
       large: "px-8 py-3 text-lg",
     },

--- a/components/Slider/Slider.tsx
+++ b/components/Slider/Slider.tsx
@@ -5,15 +5,17 @@ import { v4 as uuidv4 } from "uuid";
 
 import { Movie } from "@/model/movie";
 import { Serial } from "@/model/serial";
-import { AppRoutes } from "@/types/enums";
+import { AppRoutes, SeeMoreRoutes } from "@/types/enums";
 
 import { useSliderActions } from "./hooks/useSliderActions";
 import SliderThumbnail from "./SliderThumbnail";
+import Button from "../Button";
 
 export interface SliderProps<T> {
   data: T[];
   title: string;
   className?: string;
+  seeMoreRoute?: SeeMoreRoutes;
   route?: AppRoutes;
 }
 
@@ -21,14 +23,28 @@ const Slider = <T extends Movie & Serial>({
   data,
   title,
   className,
+  seeMoreRoute,
   route,
 }: SliderProps<T>) => {
-  const { isActionButtonClicked, rowRef, onActionIconClick } =
-    useSliderActions();
+  const {
+    isActionButtonClicked,
+    rowRef,
+    onActionIconClick,
+    onRedirectToSeeMorePage,
+  } = useSliderActions({ seeMoreRoute });
 
   return (
     <section className={clsx("space-y-0.5 md:space-y-2 pl-[5%]", className)}>
-      <h2 className="slider-header-title ">{title}</h2>
+      <div className="flex justify-between items-center pr-2 mb-2">
+        <h2 className="slider-header-title">{title}</h2>
+        <Button
+          size="small"
+          variant="primary"
+          onClick={onRedirectToSeeMorePage}
+        >
+          See More
+        </Button>
+      </div>
       <div className="group relative md:-ml-2">
         <BsChevronLeft
           className={clsx("left-arrow-slider-icon", [

--- a/components/Slider/hooks/useSliderActions.tsx
+++ b/components/Slider/hooks/useSliderActions.tsx
@@ -1,15 +1,27 @@
+import { useRouter } from "next/router";
 import { MutableRefObject, useRef, useState } from "react";
+
+import { SeeMoreRoutes } from "@/types/enums";
+
+type HookProps = {
+  seeMoreRoute?: SeeMoreRoutes;
+};
 
 type ReturnedHookType = {
   isActionButtonClicked: boolean;
   rowRef: MutableRefObject<HTMLDivElement | null>;
   onActionIconClick: (direction: string) => void;
+  onRedirectToSeeMorePage: () => void;
 };
 
-export const useSliderActions = (): ReturnedHookType => {
+export const useSliderActions = ({
+  seeMoreRoute,
+}: HookProps): ReturnedHookType => {
   const rowRef = useRef<HTMLDivElement | null>(null);
   const [isActionButtonClicked, setIsActionButtonClicked] =
     useState<boolean>(false);
+
+  const router = useRouter();
 
   const onActionIconClick = (direction: string) => {
     setIsActionButtonClicked(true);
@@ -26,9 +38,14 @@ export const useSliderActions = (): ReturnedHookType => {
     }
   };
 
+  const onRedirectToSeeMorePage = () => {
+    seeMoreRoute && router.push(seeMoreRoute);
+  };
+
   return {
     isActionButtonClicked,
     rowRef,
     onActionIconClick,
+    onRedirectToSeeMorePage,
   };
 };

--- a/hooks/useFetchSeeMorePageData.tsx
+++ b/hooks/useFetchSeeMorePageData.tsx
@@ -1,0 +1,43 @@
+import {
+  FetchNextPageOptions,
+  InfiniteData,
+  InfiniteQueryObserverResult,
+  useInfiniteQuery,
+} from "react-query";
+
+import { SeeMorePageQueryString } from "@/types/enums";
+import { MovieOrSerialResult, Status } from "@/types/interfaces";
+
+export type HookProps = {
+  query: SeeMorePageQueryString;
+  fetcher: () => Promise<MovieOrSerialResult | null>;
+};
+
+export type ReturnedHookType = {
+  data?: InfiniteData<MovieOrSerialResult | null>;
+  status: Status;
+  fetchNextPage: (
+    options?: FetchNextPageOptions | undefined
+  ) => Promise<InfiniteQueryObserverResult<MovieOrSerialResult | null, Error>>;
+  hasNextPage?: boolean;
+};
+
+export const useFetchSeeMorePageData = ({
+  query,
+  fetcher,
+}: HookProps): ReturnedHookType => {
+  const { data, status, fetchNextPage, hasNextPage } = useInfiniteQuery<
+    MovieOrSerialResult | null,
+    Error
+  >([query], fetcher, {
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+  });
+
+  return {
+    data,
+    status,
+    fetchNextPage,
+    hasNextPage,
+  };
+};

--- a/modules/home/home.service.ts
+++ b/modules/home/home.service.ts
@@ -1,5 +1,9 @@
 import { toastService } from "@/services/toast.service";
-import { HomePageData, MovieOrSerialDetailsData } from "@/types/interfaces";
+import {
+  HomePageData,
+  MovieOrSerialDetailsData,
+  MovieOrSerialResult,
+} from "@/types/interfaces";
 import {
   requestsConfigForHomePage,
   requestsConfigForMovieDetailsPage,
@@ -52,6 +56,22 @@ class HomePageService {
       const errorMessage = getResponseErrorMessage();
       toastService.error(errorMessage);
 
+      throw new Error((error as Error).message);
+    }
+  }
+
+  async fetchSeeMorePageDataForHomePage(
+    url: string
+  ): Promise<MovieOrSerialResult | null> {
+    try {
+      const response = await fetch(url);
+
+      if (!response) {
+        return null;
+      }
+
+      return await response.json();
+    } catch (error) {
       throw new Error((error as Error).message);
     }
   }

--- a/modules/movies/movies.service.ts
+++ b/modules/movies/movies.service.ts
@@ -1,5 +1,9 @@
 import { toastService } from "@/services/toast.service";
-import { MovieOrSerialDetailsData, MoviesPageData } from "@/types/interfaces";
+import {
+  MovieOrSerialDetailsData,
+  MovieOrSerialResult,
+  MoviesPageData,
+} from "@/types/interfaces";
 import {
   requestsConfigForMovieDetailsPage,
   requestsConfigForMoviesPage,
@@ -92,6 +96,22 @@ class MoviesPageService {
       const errorMessage = getResponseErrorMessageForDetailsPage();
       toastService.error(errorMessage);
 
+      throw new Error((error as Error).message);
+    }
+  }
+
+  async fetchSeeMorePageDataForMoviesPage(
+    url: string
+  ): Promise<MovieOrSerialResult | null> {
+    try {
+      const response = await fetch(url);
+
+      if (!response) {
+        return null;
+      }
+
+      return await response.json();
+    } catch (error) {
       throw new Error((error as Error).message);
     }
   }

--- a/modules/serials/serials.service.ts
+++ b/modules/serials/serials.service.ts
@@ -1,5 +1,9 @@
 import { toastService } from "@/services/toast.service";
-import { MovieOrSerialDetailsData, SerialsPageData } from "@/types/interfaces";
+import {
+  MovieOrSerialDetailsData,
+  MovieOrSerialResult,
+  SerialsPageData,
+} from "@/types/interfaces";
 import {
   requestsConfigForSerialDetailsPage,
   requestsConfigForSerialsPage,
@@ -75,6 +79,22 @@ class SerialsPageService {
       const errorMessage = getResponseErrorMessageForDetailsPage(true);
       toastService.error(errorMessage);
 
+      throw new Error((error as Error).message);
+    }
+  }
+
+  async fetchSeeMorePageDataForSerialsPage(
+    url: string
+  ): Promise<MovieOrSerialResult | null> {
+    try {
+      const response = await fetch(url);
+
+      if (!response) {
+        return null;
+      }
+
+      return await response.json();
+    } catch (error) {
       throw new Error((error as Error).message);
     }
   }

--- a/pages/home/[movieId]/index.tsx
+++ b/pages/home/[movieId]/index.tsx
@@ -1,26 +1,20 @@
 import { GetServerSideProps, NextPage } from "next";
-import { QueryClient, dehydrate } from "react-query";
 
 import { useFetchMoviesOrSerialsData } from "@/hooks/useFetchMoviesOrSerialsData";
 import { homePageService } from "@/modules/home/home.service";
 import { QueryString } from "@/types/enums";
+import { prefetchMovieOrSerialDetailsData } from "@/utils/utils";
 
 import DetailsPage from "../../../components/DetailsPage";
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const { movieId } = context.query;
 
-  const queryClient = new QueryClient();
-
-  await queryClient.prefetchQuery(QueryString.moviesForHomePageDetails, () =>
-    homePageService.fetchMoviesDetailsData(movieId)
-  );
-
-  return {
-    props: {
-      dehydratedState: JSON.parse(JSON.stringify(dehydrate(queryClient))),
-    },
-  };
+  return prefetchMovieOrSerialDetailsData({
+    id: movieId as string,
+    queryString: QueryString.moviesForHomePageDetails,
+    fetcher: () => homePageService.fetchMoviesDetailsData(movieId),
+  });
 };
 
 const MovieDetailsPage: NextPage = () => {

--- a/pages/home/index.tsx
+++ b/pages/home/index.tsx
@@ -1,23 +1,15 @@
 import { GetServerSideProps, NextPage } from "next";
-import { QueryClient, dehydrate } from "react-query";
 
 import Home from "@/modules/home";
 import { homePageService } from "@/modules/home/home.service";
 import { QueryString } from "@/types/enums";
+import { prefetchMovieOrSerialData } from "@/utils/utils";
 
 export const getServerSideProps: GetServerSideProps = async () => {
-  const queryClient = new QueryClient();
-
-  await queryClient.prefetchQuery(
+  return prefetchMovieOrSerialData(
     QueryString.moviesForHomePage,
     homePageService.fetchMoviesForHomePage
   );
-
-  return {
-    props: {
-      dehydratedState: JSON.parse(JSON.stringify(dehydrate(queryClient))),
-    },
-  };
 };
 
 const HomePage: NextPage = () => {

--- a/pages/home/now-playing/index.tsx
+++ b/pages/home/now-playing/index.tsx
@@ -1,0 +1,30 @@
+import { GetServerSideProps, NextPage } from "next";
+
+import { useFetchSeeMorePageData } from "@/hooks/useFetchSeeMorePageData";
+import { homePageService } from "@/modules/home/home.service";
+import { QueryString, SeeMorePageQueryString } from "@/types/enums";
+import { requestsConfigForSeeMorePage } from "@/utils/requests";
+import { prefetchMovieOrSerialData } from "@/utils/utils";
+
+export const getServerSideProps: GetServerSideProps = async () => {
+  return prefetchMovieOrSerialData(
+    QueryString.moviesForHomePage,
+    homePageService.fetchMoviesForHomePage
+  );
+};
+
+const NowPlayingMoviesPage: NextPage = () => {
+  const { data } = useFetchSeeMorePageData({
+    query: SeeMorePageQueryString.NowPlayingMovies,
+    fetcher: () =>
+      homePageService.fetchSeeMorePageDataForHomePage(
+        requestsConfigForSeeMorePage().fetchNowPlayingMovies
+      ),
+  });
+
+  console.log("Now Playing", { data });
+
+  return <div>NowPlayingPage</div>;
+};
+
+export default NowPlayingMoviesPage;

--- a/pages/home/popular/index.tsx
+++ b/pages/home/popular/index.tsx
@@ -1,0 +1,30 @@
+import { GetServerSideProps, NextPage } from "next";
+
+import { useFetchSeeMorePageData } from "@/hooks/useFetchSeeMorePageData";
+import { homePageService } from "@/modules/home/home.service";
+import { QueryString, SeeMorePageQueryString } from "@/types/enums";
+import { requestsConfigForSeeMorePage } from "@/utils/requests";
+import { prefetchMovieOrSerialData } from "@/utils/utils";
+
+export const getServerSideProps: GetServerSideProps = async () => {
+  return prefetchMovieOrSerialData(
+    QueryString.moviesForHomePage,
+    homePageService.fetchMoviesForHomePage
+  );
+};
+
+const PopularMoviesPage: NextPage = () => {
+  const { data } = useFetchSeeMorePageData({
+    query: SeeMorePageQueryString.PopularMovies,
+    fetcher: () =>
+      homePageService.fetchSeeMorePageDataForHomePage(
+        requestsConfigForSeeMorePage().fetchPopularMovies
+      ),
+  });
+
+  console.log("Popular", { data });
+
+  return <div>PopularMoviesPage</div>;
+};
+
+export default PopularMoviesPage;

--- a/pages/home/top-rated/index.tsx
+++ b/pages/home/top-rated/index.tsx
@@ -1,0 +1,30 @@
+import { GetServerSideProps, NextPage } from "next";
+
+import { useFetchSeeMorePageData } from "@/hooks/useFetchSeeMorePageData";
+import { homePageService } from "@/modules/home/home.service";
+import { QueryString, SeeMorePageQueryString } from "@/types/enums";
+import { requestsConfigForSeeMorePage } from "@/utils/requests";
+import { prefetchMovieOrSerialData } from "@/utils/utils";
+
+export const getServerSideProps: GetServerSideProps = async () => {
+  return prefetchMovieOrSerialData(
+    QueryString.moviesForHomePage,
+    homePageService.fetchMoviesForHomePage
+  );
+};
+
+const TopRatedMoviesPage: NextPage = () => {
+  const { data } = useFetchSeeMorePageData({
+    query: SeeMorePageQueryString.TopRatedMovies,
+    fetcher: () =>
+      homePageService.fetchSeeMorePageDataForHomePage(
+        requestsConfigForSeeMorePage().fetchTopRatedMovies
+      ),
+  });
+
+  console.log("Top Rated", { data });
+
+  return <div>TopRatedMoviesPage</div>;
+};
+
+export default TopRatedMoviesPage;

--- a/pages/home/trending/index.tsx
+++ b/pages/home/trending/index.tsx
@@ -1,0 +1,30 @@
+import { GetServerSideProps, NextPage } from "next";
+
+import { useFetchSeeMorePageData } from "@/hooks/useFetchSeeMorePageData";
+import { homePageService } from "@/modules/home/home.service";
+import { QueryString, SeeMorePageQueryString } from "@/types/enums";
+import { requestsConfigForSeeMorePage } from "@/utils/requests";
+import { prefetchMovieOrSerialData } from "@/utils/utils";
+
+export const getServerSideProps: GetServerSideProps = async () => {
+  return prefetchMovieOrSerialData(
+    QueryString.moviesForHomePage,
+    homePageService.fetchMoviesForHomePage
+  );
+};
+
+const TrendingMoviesPage: NextPage = () => {
+  const { data } = useFetchSeeMorePageData({
+    query: SeeMorePageQueryString.TrendingMovies,
+    fetcher: () =>
+      homePageService.fetchSeeMorePageDataForHomePage(
+        requestsConfigForSeeMorePage().fetchTrendingMovies
+      ),
+  });
+
+  console.log("Trending", { data });
+
+  return <div>TrendingMoviesPage</div>;
+};
+
+export default TrendingMoviesPage;

--- a/pages/home/upcoming/index.tsx
+++ b/pages/home/upcoming/index.tsx
@@ -1,0 +1,30 @@
+import { GetServerSideProps, NextPage } from "next";
+
+import { useFetchSeeMorePageData } from "@/hooks/useFetchSeeMorePageData";
+import { homePageService } from "@/modules/home/home.service";
+import { QueryString, SeeMorePageQueryString } from "@/types/enums";
+import { requestsConfigForSeeMorePage } from "@/utils/requests";
+import { prefetchMovieOrSerialData } from "@/utils/utils";
+
+export const getServerSideProps: GetServerSideProps = async () => {
+  return prefetchMovieOrSerialData(
+    QueryString.moviesForHomePage,
+    homePageService.fetchMoviesForHomePage
+  );
+};
+
+const UpcomingMoviesPage: NextPage = () => {
+  const { data } = useFetchSeeMorePageData({
+    query: SeeMorePageQueryString.UpcomingMovies,
+    fetcher: () =>
+      homePageService.fetchSeeMorePageDataForHomePage(
+        requestsConfigForSeeMorePage().fetchUpcomingMovies
+      ),
+  });
+
+  console.log("Upcoming", { data });
+
+  return <div>UpcomingMoviesPage</div>;
+};
+
+export default UpcomingMoviesPage;

--- a/pages/movies/[movieByGenreId]/index.tsx
+++ b/pages/movies/[movieByGenreId]/index.tsx
@@ -1,25 +1,20 @@
 import { GetServerSideProps, NextPage } from "next";
-import { QueryClient, dehydrate } from "react-query";
 
 import DetailsPage from "@/components/DetailsPage";
 import { useFetchMoviesOrSerialsData } from "@/hooks/useFetchMoviesOrSerialsData";
 import { moviesPageService } from "@/modules/movies/movies.service";
 import { QueryString } from "@/types/enums";
+import { prefetchMovieOrSerialDetailsData } from "@/utils/utils";
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const { movieByGenreId } = context.query;
 
-  const queryClient = new QueryClient();
-
-  await queryClient.prefetchQuery(QueryString.moviesByGenreDetails, () =>
-    moviesPageService.fetchMoviesByGenreDetailsData(movieByGenreId)
-  );
-
-  return {
-    props: {
-      dehydratedState: JSON.parse(JSON.stringify(dehydrate(queryClient))),
-    },
-  };
+  return prefetchMovieOrSerialDetailsData({
+    id: movieByGenreId as string,
+    queryString: QueryString.moviesByGenreDetails,
+    fetcher: () =>
+      moviesPageService.fetchMoviesByGenreDetailsData(movieByGenreId),
+  });
 };
 
 const MovieByGenreDetailsPage: NextPage = () => {

--- a/pages/movies/index.tsx
+++ b/pages/movies/index.tsx
@@ -1,23 +1,15 @@
 import { GetServerSideProps, NextPage } from "next";
-import { QueryClient, dehydrate } from "react-query";
 
 import Movies from "@/modules/movies";
 import { moviesPageService } from "@/modules/movies/movies.service";
 import { QueryString } from "@/types/enums";
+import { prefetchMovieOrSerialData } from "@/utils/utils";
 
 export const getServerSideProps: GetServerSideProps = async () => {
-  const queryClient = new QueryClient();
-
-  await queryClient.prefetchQuery(
+  return prefetchMovieOrSerialData(
     QueryString.moviesByGenre,
     moviesPageService.fetchMoviesByGenre
   );
-
-  return {
-    props: {
-      dehydratedState: JSON.parse(JSON.stringify(dehydrate(queryClient))),
-    },
-  };
 };
 
 const MoviesPage: NextPage = () => {

--- a/pages/serials/[serialId]/index.tsx
+++ b/pages/serials/[serialId]/index.tsx
@@ -1,25 +1,19 @@
 import { GetServerSideProps, NextPage } from "next";
-import { QueryClient, dehydrate } from "react-query";
 
 import DetailsPage from "@/components/DetailsPage";
 import { useFetchMoviesOrSerialsData } from "@/hooks/useFetchMoviesOrSerialsData";
 import { serialsPageService } from "@/modules/serials/serials.service";
 import { QueryString } from "@/types/enums";
+import { prefetchMovieOrSerialDetailsData } from "@/utils/utils";
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const { serialId } = context.query;
 
-  const queryClient = new QueryClient();
-
-  await queryClient.prefetchQuery(QueryString.serialDetails, () =>
-    serialsPageService.fetchSerialDetailsData(serialId)
-  );
-
-  return {
-    props: {
-      dehydratedState: JSON.parse(JSON.stringify(dehydrate(queryClient))),
-    },
-  };
+  return prefetchMovieOrSerialDetailsData({
+    id: serialId as string,
+    queryString: QueryString.serialDetails,
+    fetcher: () => serialsPageService.fetchSerialDetailsData(serialId),
+  });
 };
 
 const SerialDetailsPage: NextPage = () => {

--- a/pages/serials/index.tsx
+++ b/pages/serials/index.tsx
@@ -1,23 +1,15 @@
 import { GetServerSideProps, NextPage } from "next";
-import { QueryClient, dehydrate } from "react-query";
 
 import Serials from "@/modules/serials/Serials";
 import { serialsPageService } from "@/modules/serials/serials.service";
 import { QueryString } from "@/types/enums";
+import { prefetchMovieOrSerialData } from "@/utils/utils";
 
 export const getServerSideProps: GetServerSideProps = async () => {
-  const queryClient = new QueryClient();
-
-  await queryClient.prefetchQuery(
+  return prefetchMovieOrSerialData(
     QueryString.serials,
     serialsPageService.fetchSerialsData
   );
-
-  return {
-    props: {
-      dehydratedState: JSON.parse(JSON.stringify(dehydrate(queryClient))),
-    },
-  };
 };
 
 const SerialsPage: NextPage = () => {

--- a/types/constants.ts
+++ b/types/constants.ts
@@ -1,4 +1,4 @@
-import { AppRoutes } from "./enums";
+import { AppRoutes, SeeMoreRoutes } from "./enums";
 
 export const protectedRoutes = [
   AppRoutes.Home,
@@ -9,6 +9,11 @@ export const protectedRoutes = [
   AppRoutes.SerialDetails,
   AppRoutes.Profile,
   AppRoutes.Default,
+  SeeMoreRoutes.NowPlaying,
+  SeeMoreRoutes.Popular,
+  SeeMoreRoutes.TopRated,
+  SeeMoreRoutes.Trending,
+  SeeMoreRoutes.Upcoming,
 ];
 
 export const DEFAULT_SCROLL_POSITION_THRESHOLD = 80;

--- a/types/enums.ts
+++ b/types/enums.ts
@@ -79,3 +79,31 @@ export enum HeroContentActionButtons {
   ViewDetails = "View Details",
   Play = "Play Trailer",
 }
+
+export enum SeeMoreRoutes {
+  NowPlaying = "/home/now-playing",
+  Popular = "/home/popular",
+  TopRated = "/home/top-rated",
+  Trending = "/home/trending",
+  Upcoming = "/home/upcoming",
+}
+
+export enum SeeMorePageQueryString {
+  PopularMovies = "Popular Movies",
+  TopRatedMovies = "Top Rated Movies",
+  NowPlayingMovies = "Now Playing",
+  TrendingMovies = "Trending",
+  UpcomingMovies = "Upcoming",
+  ActionMovies = "Action",
+  ComedyMovies = "Comedy",
+  HorrorMovies = "Horror",
+  ThrillerMovies = "Thriller",
+  HistoryMovies = "History",
+  Documentaries = "Documentaries",
+  WarMovies = "War",
+  WesternMovies = "Western",
+  SerialsAiringToday = "Airing Today",
+  SerialsOnAir = "On The Air",
+  PopularSerials = "Popular Serials",
+  TopRatedSerials = "Top Rated Serials",
+}

--- a/types/interfaces.ts
+++ b/types/interfaces.ts
@@ -17,6 +17,7 @@ import {
   DetailsBlockTitle,
   DetailsPageActionButtons,
   HeroContentActionButtons,
+  SeeMoreRoutes,
 } from "@/types/enums";
 
 import { RequestMethod, SliderTitle } from "./enums";
@@ -119,6 +120,7 @@ export interface SliderConfig {
   isHomePage?: boolean;
   isMoviesPage?: boolean;
   isSerialsPage?: boolean;
+  seeMoreRoute?: SeeMoreRoutes;
   route?: AppRoutes;
 }
 
@@ -185,3 +187,5 @@ export interface HeroContentActionButton {
   variant: ButtonVariant;
   onClick: () => void;
 }
+
+export type Status = "idle" | "error" | "loading" | "success";

--- a/utils/requests.ts
+++ b/utils/requests.ts
@@ -49,3 +49,31 @@ export const requestsConfigForSerialDetailsPage = (
   fetchDataForSerialDetailsPage: `${BASE_URL}/tv/${serialId}?api_key=${API_KEY}&language=en-US&append_to_response=videos`,
   fetchSerialActors: `${BASE_URL}/tv/${serialId}/credits?api_key=${API_KEY}&language=en-US`,
 });
+
+export const requestsConfigForSeeMorePage = (
+  pageCount = 1
+): ApiRequestConfigForHomePage &
+  ApiRequestConfigForMoviesPage &
+  ApiRequestConfigForSerialsPage => {
+  return {
+    fetchTrendingMovies: `${BASE_URL}/trending/all/week?api_key=${API_KEY}&language=en-US&page=${pageCount}`,
+    fetchTopRatedMovies: `${BASE_URL}/movie/top_rated?api_key=${API_KEY}&language=en-US&page=${pageCount}`,
+    fetchUpcomingMovies: `${BASE_URL}/movie/upcoming?api_key=${API_KEY}&language=en-US&page=${pageCount}`,
+    fetchPopularMovies: `${BASE_URL}/movie/popular?api_key=${API_KEY}&language=en-US&page=${pageCount}`,
+    fetchLatestMovies: `${BASE_URL}/movie/latest?api_key=${API_KEY}&language=en-US&page=${pageCount}`,
+    fetchNowPlayingMovies: `${BASE_URL}/movie/now_playing?api_key=${API_KEY}&language=en-US&page=${pageCount}`,
+    fetchActionMovies: `${BASE_URL}/discover/movie?api_key=${API_KEY}&language=en-US&with_genres=28&page=${pageCount}`,
+    fetchComedyMovies: `${BASE_URL}/discover/movie?api_key=${API_KEY}&language=en-US&with_genres=35&page=${pageCount}`,
+    fetchHorrorMovies: `${BASE_URL}/discover/movie?api_key=${API_KEY}&language=en-US&with_genres=27&page=${pageCount}`,
+    fetchThrillerMovies: `${BASE_URL}/discover/movie?api_key=${API_KEY}&language=en-US&with_genres=53&page=${pageCount}`,
+    fetchHistoryMovies: `${BASE_URL}/discover/movie?api_key=${API_KEY}&language=en-US&with_genres=36&page=${pageCount}`,
+    fetchDocumentariesMovies: `${BASE_URL}/discover/movie?api_key=${API_KEY}&language=en-US&with_genres=99&page=${pageCount}`,
+    fetchWarMovies: `${BASE_URL}/discover/movie?api_key=${API_KEY}&language=en-US&with_genres=10752&page=${pageCount}`,
+    fetchWesternMovies: `${BASE_URL}/discover/movie?api_key=${API_KEY}&language=en-US&with_genres=37&page=${pageCount}`,
+    fetchLatestSerials: `${BASE_URL}/tv/latest?api_key=${API_KEY}&language=en-US&page=${pageCount}`,
+    fetchSerialsAiringToday: `${BASE_URL}/tv/airing_today?api_key=${API_KEY}&language=en-US&page=${pageCount}`,
+    fetchSerialsOnAir: `${BASE_URL}/tv/on_the_air?api_key=${API_KEY}&language=en-US&page=${pageCount}`,
+    fetchPopularSerials: `${BASE_URL}/tv/popular?api_key=${API_KEY}&language=en-US&page=${pageCount}`,
+    fetchTopRatedSerials: `${BASE_URL}/tv/top_rated?api_key=${API_KEY}&language=en-US&page=${pageCount}`,
+  };
+};

--- a/utils/utils.tsx
+++ b/utils/utils.tsx
@@ -8,6 +8,7 @@ import {
   BsFillArrowLeftCircleFill,
   BsFillInfoCircleFill,
 } from "react-icons/bs";
+import { QueryClient, dehydrate } from "react-query";
 import { v4 as uuidv4 } from "uuid";
 
 import Button from "@/components/Button";
@@ -20,7 +21,9 @@ import {
   DetailsBlockTitle,
   DetailsPageActionButtons,
   HeroContentActionButtons,
+  QueryString,
   RequestMethod,
+  SeeMoreRoutes,
   SliderTitle,
 } from "@/types/enums";
 import {
@@ -29,8 +32,12 @@ import {
   DetailsPageActionButton,
   HeroContentActionButton,
   HeroContentActionButtonConfig,
+  HomePageData,
+  MovieOrSerialDetailsData,
   MovieOrSerialWithRegularSubtitle,
+  MoviesPageData,
   PageSlider,
+  SerialsPageData,
   SliderConfig,
 } from "@/types/interfaces";
 
@@ -105,6 +112,7 @@ const sliderConfig = <T extends AppPageData>({
       title: SliderTitle.NowPlayingMovies,
       className: commonClassName,
       isHomePage,
+      seeMoreRoute: SeeMoreRoutes.NowPlaying,
       route,
     },
     {
@@ -113,6 +121,7 @@ const sliderConfig = <T extends AppPageData>({
       title: SliderTitle.PopularMoviesOrSerials,
       className: commonClassName,
       isHomePage,
+      seeMoreRoute: SeeMoreRoutes.Popular,
       route,
     },
     {
@@ -121,6 +130,7 @@ const sliderConfig = <T extends AppPageData>({
       title: SliderTitle.PopularMoviesOrSerials,
       className: commonClassName,
       isSerialsPage,
+      seeMoreRoute: SeeMoreRoutes.Popular,
       route,
     },
     {
@@ -153,6 +163,7 @@ const sliderConfig = <T extends AppPageData>({
       title: SliderTitle.TopRatedMoviesOrSerials,
       className: commonClassName,
       isHomePage,
+      seeMoreRoute: SeeMoreRoutes.TopRated,
       route,
     },
     {
@@ -161,6 +172,7 @@ const sliderConfig = <T extends AppPageData>({
       title: SliderTitle.TopRatedMoviesOrSerials,
       className: commonClassName,
       isSerialsPage,
+      seeMoreRoute: SeeMoreRoutes.TopRated,
       route,
     },
     {
@@ -169,6 +181,7 @@ const sliderConfig = <T extends AppPageData>({
       title: SliderTitle.TrendingMovies,
       className: commonClassName,
       isHomePage,
+      seeMoreRoute: SeeMoreRoutes.Trending,
       route,
     },
     {
@@ -177,6 +190,7 @@ const sliderConfig = <T extends AppPageData>({
       title: SliderTitle.UpcomingMovies,
       className: commonClassName,
       isHomePage,
+      seeMoreRoute: SeeMoreRoutes.Upcoming,
       route,
     },
     {
@@ -224,6 +238,7 @@ export const getPageSlider = <T,>({
           isMoviesPage,
           isSerialsPage,
           route,
+          seeMoreRoute,
         }) => (
           <>
             {(isHomePage || isMoviesPage || isSerialsPage) && (
@@ -232,6 +247,7 @@ export const getPageSlider = <T,>({
                 className={className}
                 data={shuffle(data)}
                 route={route}
+                seeMoreRoute={seeMoreRoute}
                 title={title}
               />
             )}
@@ -642,4 +658,41 @@ export const getTrailerUrl = async ({
   } catch {
     onSetTrailer(null);
   }
+};
+
+export const prefetchMovieOrSerialData = async <
+  T extends HomePageData | MoviesPageData | SerialsPageData
+>(
+  queryString: QueryString,
+  fetcher: () => Promise<T>
+) => {
+  const queryClient = new QueryClient();
+
+  await queryClient.prefetchQuery(queryString, fetcher);
+
+  return {
+    props: {
+      dehydratedState: JSON.parse(JSON.stringify(dehydrate(queryClient))),
+    },
+  };
+};
+
+export const prefetchMovieOrSerialDetailsData = async ({
+  id,
+  queryString,
+  fetcher,
+}: {
+  id: string;
+  queryString: QueryString;
+  fetcher: (id: string) => Promise<MovieOrSerialDetailsData>;
+}) => {
+  const queryClient = new QueryClient();
+
+  await queryClient.prefetchQuery(queryString, () => fetcher(id));
+
+  return {
+    props: {
+      dehydratedState: JSON.parse(JSON.stringify(dehydrate(queryClient))),
+    },
+  };
 };


### PR DESCRIPTION
- Add See `More button` to all sliders within `Home,` `Movies` and `Serials` Page
-  Connect `See More` page of each slider within Home Page with API (retrieve corresponding See More Page data)
- Refactor getSerSideProps function for each page